### PR TITLE
Enable wit with platform-webchat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botpress-wit",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "This module integrates Wit.ai inside Botpress for NLP",
   "main": "bin/node.bundle.js",
   "botpress": {

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import Wit from './wit'
 let wit = null
 
 const incomingMiddleware = (event, next) => {
-  if (event.type === 'message') {
+  if (event.type === 'message' || event.type === 'text') {
     if (event.bp.wit.mode === 'understanding') {
       Object.assign(wit.getUserContext(event.user.id).context, {
         botpress_platform: event.platform,


### PR DESCRIPTION
This enables using `botpress-wit` as NLP for `botpress-platform-webchat`.

Thank you to @blazgrapar for pointing me in the right direction:
https://botpress-community.slack.com/archives/C3TQB8FBM/p1511297175000437 

Fixes https://github.com/botpress/botpress-platform-webchat/issues/15